### PR TITLE
Update pyproject.toml, Fix wrong sklearn dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires = [
     "h5py",
     "anndata",
     "scanpy",
-    "sklearn",
+    "scikit-learn",
     "umap-learn",
     "numba",
     "loompy",


### PR DESCRIPTION
Hi,

I accidentally saw that sklearn==0.0 is installed after the installation of the muon package.
So, it seems that [sklearn](https://pypi.org/project/sklearn/) that is an empty non-safe project is used rather than [scikit-learn](https://pypi.org/project/scikit-learn/) (correct) package.

Note: scikit-learn will be installed anyway since scanpy needs it. 