### PR TITLE
Fix save color in MuData

### DIFF
--- a/muon/_atac/plot.py
+++ b/muon/_atac/plot.py
@@ -166,13 +166,14 @@ def embedding(
         ad = AnnData(x, obs=adata.obs, obsm=adata.obsm)
         retval = sc.pl.embedding(ad, basis=basis, color=attr_names, **kwargs)
         for aname in attr_names:
-            adata.uns[f"{aname}_colors"] = ad.uns[f"{aname}_colors"]
+            try:
+                adata.uns[f"{aname}_colors"] = ad.uns[f"{aname}_colors"]
+            except KeyError:
+                pass
         return retval
 
     else:
         return sc.pl.embedding(adata, basis=basis, use_raw=use_raw, layer=layer, **kwargs)
-
-    return None
 
 
 def pca(data: Union[AnnData, MuData], **kwargs) -> Union[Axes, List[Axes], None]:

--- a/muon/_core/plot.py
+++ b/muon/_core/plot.py
@@ -87,7 +87,10 @@ def scatter(
     retval = sc.pl.scatter(ad, x=x, y=y, color=color, **kwargs)
     if color is not None:
         for col in color:
-            data.uns[f"{col}_colors"] = ad.uns[f"{col}_colors"]
+            try:
+                data.uns[f"{col}_colors"] = ad.uns[f"{col}_colors"]
+            except KeyError:
+                pass
     return retval
 
 
@@ -259,7 +262,10 @@ def embedding(
     ad = AnnData(obs=obs, obsm=adata.obsm, obsp=adata.obsp, uns=adata.uns)
     retval = sc.pl.embedding(ad, basis=basis_mod, color=color, **kwargs)
     for key, col in zip(keys, color):
-        adata.uns[f"{key}_colors"] = ad.uns[f"{col}_colors"]
+        try:
+            adata.uns[f"{key}_colors"] = ad.uns[f"{col}_colors"]
+        except KeyError:
+            pass
     return retval
 
 


### PR DESCRIPTION
Fixes a regression introduced in 19f98d2ef80463b7e691b5b69030158838ec216b.
The problem is that for continuous variables, no color
gets stored in AnnData, therefore plotting continuous variables with
muon fails at the moment.
