### PR TITLE
:sparkles: Extend _l2norm for sparse input

### DIFF
--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -159,17 +159,19 @@ def _l2norm(
     if sparse_X:
         X_norm = linalg.norm(X, ord=2, axis=1)
         norm = X / np.expand_dims(X_norm, axis=1)
-        # find nan and infinite values and construct matrix without
-        i, j, val = find(norm)
-        isfin = np.isfinite(val)
-        i = i[isfin]
-        j = j[isfin]
-        norm = csr_matrix((val, (i, j)), shape=X.shape)
+        if issparse(norm):
+            # find nan and infinite values and construct matrix without
+            i, j, val = find(norm)
+            isfin = np.isfinite(val)
+            i = i[isfin]
+            j = j[isfin]
+            norm = csr_matrix((val, (i, j)), shape=X.shape)
     else:
         norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
         norm[~np.isfinite(norm)] = 0
     X.astype(norm.dtype, copy=False)
     if sparse_X and not issparse(norm):
+        norm[~np.isfinite(norm)] = 0
         X = X.toarray()
     X[:] = norm
 

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -165,6 +165,7 @@ def _l2norm(
             isfin = np.isfinite(val)
             i = i[isfin]
             j = j[isfin]
+            val = val[isfin]
             norm = csr_matrix((val, (i, j)), shape=X.shape)
     else:
         norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -159,12 +159,12 @@ def _l2norm(
     if sparse_X:
         X_norm = linalg.norm(X, ord=2, axis=1)
         norm = X / np.expand_dims(X_norm, axis=1)
-        #find nan and infinite values and construct matrix without 
-        i,j,val = find(norm)
+        # find nan and infinite values and construct matrix without
+        i, j, val = find(norm)
         isfin = np.isfinite(val)
         i = i[isfin]
         j = j[isfin]
-        norm = csr_matrix((val, (i,j)), shape=X.shape)
+        norm = csr_matrix((val, (i, j)), shape=X.shape)
     else:
         norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
         norm[~np.isfinite(norm)] = 0

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -4,7 +4,7 @@ import warnings
 from itertools import repeat
 
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning, linalg
 from scipy.spatial.distance import cdist
 from scipy.special import softmax
 from sklearn.utils import check_random_state
@@ -155,7 +155,11 @@ def _l2norm(
     adata: AnnData, rep: Optional[Union[Iterable[str], str]] = None, n_pcs: Optional[int] = 0
 ):
     X = _choose_representation(adata, rep, n_pcs)
-    norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
+    if issparse(X):
+        X_norm = linalg.norm(X, ord=2, axis=1) 
+        norm = X / np.expand_dims(X_norm, axis=1)
+    else:
+        norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
     norm[~np.isfinite(norm)] = 0
     X.astype(norm.dtype, copy=False)
     X[:] = norm

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -4,7 +4,7 @@ import warnings
 from itertools import repeat
 
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning, linalg
+from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning, linalg, find
 from scipy.spatial.distance import cdist
 from scipy.special import softmax
 from sklearn.utils import check_random_state
@@ -155,13 +155,22 @@ def _l2norm(
     adata: AnnData, rep: Optional[Union[Iterable[str], str]] = None, n_pcs: Optional[int] = 0
 ):
     X = _choose_representation(adata, rep, n_pcs)
-    if issparse(X):
-        X_norm = linalg.norm(X, ord=2, axis=1) 
+    sparse_X = issparse(X)
+    if sparse_X:
+        X_norm = linalg.norm(X, ord=2, axis=1)
         norm = X / np.expand_dims(X_norm, axis=1)
+        #find nan and infinite values and construct matrix without 
+        i,j,val = find(norm)
+        isfin = np.isfinite(val)
+        i = i[isfin]
+        j = j[isfin]
+        norm = csr_matrix((val, (i,j)), shape=X.shape)
     else:
         norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
-    norm[~np.isfinite(norm)] = 0
+        norm[~np.isfinite(norm)] = 0
     X.astype(norm.dtype, copy=False)
+    if sparse_X and not issparse(norm):
+        X = X.toarray()
     X[:] = norm
 
 

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -5,7 +5,6 @@ from itertools import repeat
 
 import numpy as np
 from scipy.sparse import (
-    coo_matrix,
     csr_matrix,
     issparse,
     SparseEfficiencyWarning,

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -4,7 +4,16 @@ import warnings
 from itertools import repeat
 
 import numpy as np
-from scipy.sparse import coo_matrix, csr_matrix, issparse, SparseEfficiencyWarning, linalg, isspmatrix_csc, isspmatrix_csr, isspmatrix_coo
+from scipy.sparse import (
+    coo_matrix,
+    csr_matrix,
+    issparse,
+    SparseEfficiencyWarning,
+    linalg,
+    isspmatrix_csc,
+    isspmatrix_csr,
+    isspmatrix_coo,
+)
 from scipy.spatial.distance import cdist
 from scipy.special import softmax
 from sklearn.utils import check_random_state
@@ -167,7 +176,7 @@ def _l2norm(
         norm[~np.isfinite(norm)] = 0
     X.astype(norm.dtype, copy=False)
     if sparse_X and (isspmatrix_csc(X) or isspmatrix_csr(X) or isspmatrix_coo(X)):
-        X.data[:] = norm.data[:]       
+        X.data[:] = norm.data[:]
     else:
         X[:] = norm
 

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -159,32 +159,11 @@ def _l2norm(
     if sparse_X:
         X_norm = linalg.norm(X, ord=2, axis=1)
         norm = X / np.expand_dims(X_norm, axis=1)
-        if issparse(norm):
-            if isinstance(norm, csr_matrix):
-                # find nan and infinite values and construct matrix without
-                isfin = np.isfinite(norm.data)
-                i = norm.indices[isfin]
-                j = norm.indptr[isfin]
-                val = norm.data[isfin]
-                norm = csr_matrix((val, i, j), shape=X.shape)
-            elif isinstance(norm, coo_matrix):
-                i, j, val = find(norm)
-                isfin = np.isfinite(val)
-                i = i[isfin]
-                j = j[isfin]
-                val = val[isfin]
-                norm = csr_matrix((val, (i, j)), shape=X.shape)
-            else:
-                raise ValueError(
-                    "The normalized sparse matrix is neither `csr_matrix` nor `coo_matrix`."
-                )
+        norm.data[~np.isfinite(norm.data)] = 0
     else:
         norm = X / np.linalg.norm(X, ord=2, axis=1, keepdims=True)
         norm[~np.isfinite(norm)] = 0
     X.astype(norm.dtype, copy=False)
-    if sparse_X and not issparse(norm):
-        norm[~np.isfinite(norm)] = 0
-        X = X.toarray()
     X[:] = norm
 
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I tried to compute a WNN integration on a MuData object, i.e. I executed the following steps:
```
mu.pp.l2norm(mdata)
mu.pp.neighbors(mdata)
mu.tl.umap(mdata)
```
However, my Python session keeps crashing at the `l2norm` step. Omitting this step, computing neighbors and a UMAP works fine. I looked into the `mu.pp.l2norm` function and isolated the function `np.linalg.norm()` in the `_l2norm()` function as the culprit. It crashes reliably for sparse matrices.  Converting the data matrix into dense format fixes the issue. This PR extends the `_l2norm` function to sparse matrices. 