### PR TITLE
FIX: replace `scanpy.neighbors._compute_connectivities_umap` with `sc…

### DIFF
--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -20,7 +20,7 @@ from sklearn.utils import check_random_state
 from anndata import AnnData
 from scanpy import logging
 from scanpy.tools._utils import _choose_representation
-from scanpy.neighbors import _compute_connectivities_umap
+from scanpy.neighbors._connectivity import umap
 from umap.distances import euclidean
 from umap.sparse import sparse_euclidean, sparse_jaccard
 from umap.umap_ import nearest_neighbors
@@ -585,7 +585,7 @@ def neighbors(
     neighbordistances = _sparse_csr_fast_knn(neighbordistances, n_neighbors + 1)
 
     logging.info("Calculating connectivities...")
-    _, connectivities = _compute_connectivities_umap(
+    connectivities = umap(
         knn_indices=neighbordistances.indices.reshape(
             (neighbordistances.shape[0], n_neighbors + 1)
         ),

--- a/muon/_core/tools.py
+++ b/muon/_core/tools.py
@@ -17,7 +17,7 @@ from mudata import MuData
 
 from scanpy import logging
 from scanpy.tools._utils import _choose_representation
-from scanpy.neighbors import _compute_connectivities_umap
+# from scanpy.neighbors import _compute_connectivities_umap
 
 from typing import Union, Optional, List, Iterable, Mapping, Sequence, Type, Any, Dict, Literal
 from types import MappingProxyType


### PR DESCRIPTION
…anpy.neighbors._connectivity.umap`

Scanpy 1.10.0+ removes `scanpy.neighbors._compute_connectivites_umap`, but the required functionality is still provided by `scanpy.neighbors._connectivity.umap`, so this PR swaps those out.