### PR TITLE
make random state argument handling more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning][].
 - Selecting an `.obsm` component with a non-integer index (e.g. `X_umap:abc`) now raises a clear error.
 - Avoid a `FutureWarning` on import by querying the scanpy version via `importlib.metadata.version`
   instead of the deprecated `scanpy.__version__`.
+- `tl.leiden` now correctly sets the seed with `random_state=0`.
 
 ## [0.1.9]
 

--- a/src/muon/atac/tl.py
+++ b/src/muon/atac/tl.py
@@ -820,7 +820,7 @@ def tss_enrichment(
     extend_downstream: int = 1000,
     n_tss: int = 2000,
     return_tss: bool = True,
-    random_state: int | None = 0,
+    random_state: int | np.random.RandomState | None = 0,
     barcodes: str | None = None,
 ) -> AnnData | None:
     """Calculate TSS enrichment according to ENCODE guidelines.

--- a/src/muon/atac/tl.py
+++ b/src/muon/atac/tl.py
@@ -820,7 +820,7 @@ def tss_enrichment(
     extend_downstream: int = 1000,
     n_tss: int = 2000,
     return_tss: bool = True,
-    random_state=None,
+    random_state: int | None = 0,
     barcodes: str | None = None,
 ) -> AnnData | None:
     """Calculate TSS enrichment according to ENCODE guidelines.

--- a/src/muon/prot/pp.py
+++ b/src/muon/prot/pp.py
@@ -25,7 +25,7 @@ def dsb(
     quantile_clipping: bool = False,
     quantile_clip: tuple[float, float] = (0.001, 0.9995),
     add_layer: bool = False,
-    random_state: int | np.random.RandomState | None | None = None,
+    random_state: int | np.random.RandomState | None | None = 0,
 ) -> None | MuData:
     """Normalize protein expression with DSB (Denoised and Scaled by Background) :cite:p:`pmid35440536`.
 

--- a/src/muon/tl.py
+++ b/src/muon/tl.py
@@ -835,7 +835,7 @@ def _cluster(
     data: MuData | AnnData,
     resolution: float | Sequence[float] | Mapping[str, float] | None = None,
     mod_weights: Sequence[float] | Mapping[str, float] | None = None,
-    random_state: int = 0,
+    random_state: int | None = 0,
     key_added: str = "leiden",
     neighbors_key: str | None = None,
     directed: bool = True,
@@ -905,7 +905,7 @@ def _cluster(
         partition_type = alg.RBConfigurationVertexPartition
 
     optimiser = alg.Optimiser()
-    if random_state:
+    if random_state is not None:
         optimiser.set_rng_seed(random_state)
 
     # The same as leiden.find_partition_multiplex() (louvain.find_partition_multiplex())
@@ -951,7 +951,7 @@ def leiden(
     data: MuData | AnnData,
     resolution: float | Sequence[float] | Mapping[str, float] | None = None,
     mod_weights: Sequence[float] | Mapping[str, float] | None = None,
-    random_state: int = 0,
+    random_state: int | None = 0,
     key_added: str = "leiden",
     neighbors_key: str | None = None,
     directed: bool = True,
@@ -1015,7 +1015,7 @@ def louvain(
     data: MuData | AnnData,
     resolution: float | Sequence[float] | Mapping[str, float] | None = None,
     mod_weights: Sequence[float] | Mapping[str, float] | None = None,
-    random_state: int = 0,
+    random_state: int | None = 0,
     key_added: str = "louvain",
     neighbors_key: str | None = None,
     directed: bool = True,
@@ -1230,7 +1230,14 @@ def umap(
 
 
 def ica(
-    data: AnnData | MuData, basis="X_pca", n_components=None, *, random_state=None, scale=False, copy=False, **kwargs
+    data: AnnData | MuData,
+    basis: str = "X_pca",
+    n_components: int | None = None,
+    *,
+    random_state: int | None = 0,
+    scale: bool = False,
+    copy: bool = False,
+    **kwargs,
 ) -> AnnData | MuData | None:
     """Run Independent component analysis."""
     from sklearn.decomposition import FastICA


### PR DESCRIPTION
- always default to non-None random_state (consistent within muon and with scanpy)
- fix condition before setting random state in .tl.leiden (closes #154, closes #184, closes #218)