### PR TITLE
plotting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.2.0] (Unreleased)
 
+### Added
+
+- `pl.scatter` and `pl.embedding` have a new `gene_symbols` argument with the same functionality as in scanpy.
+
 ### Changed
 
 - muon now requires Python 3.12 or newer.
 - `pp`, `tl`, `pl`, `atac.pp`, `atac.tl`, `atac.pl` and `prot.pp` are now regular submodules,
   so they can be imported directly (e.g. `from muon.pp import neighbors`).
+- The `use_raw` argument of `muon.pl.scatter` and `muon.pl.embedding` can no longer be `None`, it must be either `True` or `False`.
+  This leads to more predictable plotting behavior.
+- The arguments `layer` and `use_raw` of `muon.pl.scatter` and `muon.pl.embedding` can be specified individually for each modality by passing dictionaries.
 
 ### Deprecated
 
@@ -29,7 +36,8 @@ and this project adheres to [Semantic Versioning][].
 - Selecting an `.obsm` component with a non-integer index (e.g. `X_umap:abc`) now raises a clear error.
 - Avoid a `FutureWarning` on import by querying the scanpy version via `importlib.metadata.version`
   instead of the deprecated `scanpy.__version__`.
-- `tl.leiden` now correctly sets the seed with `random_state=0`.
+- `muon.tl.leiden` now correctly sets the seed with `random_state=0`.
+- `muon.pl.embedding` no longer mutates its input when a layer is used.
 
 ## [0.1.9]
 

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from contextlib import suppress
 
 import numpy as np
 import pandas as pd
@@ -172,7 +173,7 @@ def embedding(
             else:
                 raise ValueError(f"Basis {basis_mod} is not present in the modality {mod} with no embeddings")
 
-    obs = data.obs.loc[adata.obs.index.values]
+    obs = data.obs.loc[adata.obs.index.values, :]
 
     if not isinstance(use_raw, Mapping):
         use_rawd = use_raw
@@ -235,10 +236,8 @@ def embedding(
     ad = AnnData(obs=obs, obsm=adata.obsm, obsp=adata.obsp, uns=adata.uns)
     retval = sc.pl.embedding(ad, basis=basis_mod, color=color, **kwargs)
     for key, col in zip(keys, color, strict=True):
-        try:
+        with suppress(KeyError):
             adata.uns[f"{key}_colors"] = ad.uns[f"{col}_colors"]
-        except KeyError:
-            pass
     return retval
 
 

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -127,9 +127,8 @@ def embedding(
             If a mapping is given, it must have one entry for each modality.
         layer: Name of the layer in the modality where a feature (from `color`) is derived from.
             A mapping from modality names to layer names can be provided in order to use a different
-            layer for each modality. No layer is used by default. If a valid `layer` is provided, this
-            takes precedence over `use_raw=True`. If a mapping is given, it must have one entry for each
-            modality.
+            layer for each modality. No layer is used by default. If a mapping is given, it must have one
+            entry for each modality.
         gene_symbols: Column of `.var` to search for `color` in. If a mapping is given, it must have one entry
             for each modality.
         **kwargs: Additional keyword arguments passed to :func:`scanpy.pl.embedding`.

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -1,6 +1,4 @@
 from collections import defaultdict
-from typing import Dict, Iterable, List, Optional, Sequence, Union, Mapping
-import warnings
 from collections.abc import Iterable, Mapping, Sequence
 
 import numpy as np
@@ -10,7 +8,6 @@ import seaborn as sns
 from anndata import AnnData
 from matplotlib.axes import Axes
 from mudata import MuData
-from scipy.sparse import sparray, spmatrix
 
 from .utils import _get_values
 
@@ -24,14 +21,18 @@ def scatter(
     x: str | None = None,
     y: str | None = None,
     color: str | Sequence[str] | None = None,
-    use_raw: bool | None = None,
-    layers: str | Sequence[str | None] | None = None,
+    use_raw: bool | Mapping[str, bool] = False,
+    layers: str
+    | tuple[str, str, str]
+    | Mapping[str, str]
+    | tuple[Mapping[str, str], Mapping[str, str], Mapping[str, str]]
+    | None = None,
+    gene_symbols: str | Mapping[str, str | None] | None = None,
     **kwargs,
 ) -> Axes | list[Axes] | None:
     """Scatter plot along observations or variables axes.
 
-    Variables in each modality can be referenced,
-    e.g. ``"rna:X_pca"``.
+    Variables in each modality can be referenced, e.g. ``"rna:X_pca"``.
 
     See :func:`scanpy.pl.scatter` for details.
 
@@ -42,21 +43,30 @@ def scatter(
         color: Keys or a single key for variables or annotations of observations (.obs columns),
             or a hex colour specification.
         use_raw: Use `.raw` attribute of the modality where a feature (from `color`) is derived from.
-            If `None`, defaults to `True` if `.raw` is present and a valid `layer` is not provided.
-        layers: Names of the layers where x, y, and color come from.
-            No layer is used by default. A single layer value will be expanded to [layer, layer, layer].
+            If a mapping is given, it must have one netry for each modality.
+        layers: Names of the layers where x, y, and color come from. No layer is used by default.
+            A single layer value will be expanded to [layer, layer, layer]. If a mapping is given, it must
+            have one entry for each modality.
+        gene_symbols: Column of `.var` to search for `color` in. If a mapping is given, it must have one
+            entry for each modality.
         **kwargs: Additional keyword arguments passed to :func:`scanpy.pl.scatter`.
     """
     if isinstance(data, AnnData):
+        localvars = locals()
+        for arg in ("use_raw", "layers", "gene_symbols"):
+            if isinstance(localvars[arg], Mapping):
+                raise ValueError(f"`{arg}` can only be a dictionary if `data` is a `MuData` object.")
         return sc.pl.scatter(data, x=x, y=y, color=color, use_raw=use_raw, layers=layers, **kwargs)
 
-    if isinstance(layers, str) or layers is None:
-        layers = [layers, layers, layers]
+    if isinstance(layers, str | Mapping) or layers is None:
+        clayers = (layers, layers, layers)
+    else:
+        clayers = layers
 
     obs = pd.DataFrame(
         {
-            x: _get_values(data, x, use_raw=use_raw, layer=layers[0]),
-            y: _get_values(data, y, use_raw=use_raw, layer=layers[1]),
+            x: _get_values(data, x, use_raw=use_raw, layer=clayers[0], gene_symbols=gene_symbols),
+            y: _get_values(data, y, use_raw=use_raw, layer=clayers[1], gene_symbols=gene_symbols),
         }
     )
     obs.index = data.obs_names
@@ -64,9 +74,11 @@ def scatter(
         # Workaround for scanpy#311, scanpy#1497
         color_obs: pd.DataFrame
         if isinstance(color, str):
-            color_obs = pd.DataFrame({color: _get_values(data, color, use_raw=use_raw, layer=layers[2])})
+            color_obs = pd.DataFrame(
+                {color: _get_values(data, color, use_raw=use_raw, layer=clayers[2], gene_symbols=gene_symbols)}
+            )
         else:
-            color_obs = _get_values(data, color, use_raw=use_raw, layer=layers[2])
+            color_obs = _get_values(data, color, use_raw=use_raw, layer=clayers[2], gene_symbols=gene_symbols)
 
         color_obs.index = data.obs_names
         obs = pd.concat([obs, color_obs], axis=1, ignore_index=False)
@@ -94,7 +106,7 @@ def embedding(
     data: AnnData | MuData,
     basis: str,
     color: str | Sequence[str] | None = None,
-    use_raw: Mapping[str, bool] = False,
+    use_raw: bool | Mapping[str, bool] = False,
     layer: str | Mapping[str, str | None] | None = None,
     gene_symbols: str | Mapping[str, str | None] | None = None,
     **kwargs,
@@ -123,7 +135,13 @@ def embedding(
         **kwargs: Additional keyword arguments passed to :func:`scanpy.pl.embedding`.
     """
     if isinstance(data, AnnData):
-        return sc.pl.embedding(data, basis=basis, color=color, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, **kwargs)
+        localvars = locals()
+        for arg in ("use_raw", "layer", "gene_symbols"):
+            if isinstance(localvars[arg], Mapping):
+                raise ValueError(f"`{arg}` can only be a dictionary if `data` is a `MuData` object.")
+        return sc.pl.embedding(
+            data, basis=basis, color=color, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, **kwargs
+        )
 
     # `data` is MuData
     if basis not in data.obsm and "X_" + basis in data.obsm:
@@ -195,7 +213,7 @@ def embedding(
         mod_key_modifier: dict[str, str] = {}
         for i, k in enumerate(keys):
             mod_key_modifier[k] = k
-            for m, mod in data.mod.items():
+            for m in data.mod.keys():
                 if not keys_in_mod[m][i]:
                     k_clean = k
                     if k.startswith(f"{m}:"):
@@ -209,13 +227,7 @@ def embedding(
             if np.sum(keys_in_mod[m]) > 0:
                 mod_keys = [mod_key_modifier[k] for i, k in enumerate(keys) if keys_in_mod[m][i]]
                 obs = obs.join(
-                    sc.get.obs_df(
-                        mod,
-                        keys=mod_keys,
-                        layer=layer[m],
-                        use_raw=use_raw[m],
-                        gene_symbols=gene_symbols[m],
-                    ),
+                    sc.get.obs_df(mod, keys=mod_keys, layer=layer[m], use_raw=use_raw[m], gene_symbols=gene_symbols[m]),
                     how="left",
                 )
 

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from typing import Dict, Iterable, List, Optional, Sequence, Union, Mapping
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
 
@@ -92,16 +94,14 @@ def embedding(
     data: AnnData | MuData,
     basis: str,
     color: str | Sequence[str] | None = None,
-    use_raw: bool | None = None,
+    use_raw: Mapping[str, bool] = False,
     layer: str | Mapping[str, str | None] | None = None,
-    gene_symbols: str | None = None,
+    gene_symbols: str | Mapping[str, str | None] | None = None,
     **kwargs,
 ) -> Axes | list[Axes] | None:
     """Scatter plot for .obs.
 
-    Produce a scatter plot in the define basis,
-    which can also be a basis inside any modality,
-    e.g. ``"rna:X_pca"``.
+    Produce a scatter plot in the define basis, which can also be a basis inside any modality, e.g. ``"rna:X_pca"``.
 
     See :func:`scanpy.pl.embedding` for details.
 
@@ -112,19 +112,18 @@ def embedding(
             Can be from any modality.
         use_raw: Use `.raw` attribute of the modality where a feature (from `color`) is derived from.
             If `None`, defaults to `True` if `.raw` is present and a valid `layer` is not provided.
+            If a mapping is given, it must have one entry for each modality.
         layer: Name of the layer in the modality where a feature (from `color`) is derived from.
-            A mapping from modality names to layer names can be provided
-            in order to use a different layer for each modality.
-            No layer is used by default. If a valid `layer` is provided, this takes precedence
-            over `use_raw=True`.
-        gene_symbols: Column of `.var` to search for `color` in.
+            A mapping from modality names to layer names can be provided in order to use a different
+            layer for each modality. No layer is used by default. If a valid `layer` is provided, this
+            takes precedence over `use_raw=True`. If a mapping is given, it must have one entry for each
+            modality.
+        gene_symbols: Column of `.var` to search for `color` in. If a mapping is given, it must have one entry
+            for each modality.
         **kwargs: Additional keyword arguments passed to :func:`scanpy.pl.embedding`.
     """
     if isinstance(data, AnnData):
         return sc.pl.embedding(data, basis=basis, color=color, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, **kwargs)
-
-    if use_raw and layer is not None:
-        raise ValueError("use_raw cannot be True when a layer is specified.")
 
     # `data` is MuData
     if basis not in data.obsm and "X_" + basis in data.obsm:
@@ -158,6 +157,16 @@ def embedding(
 
     obs = data.obs.loc[adata.obs.index.values]
 
+    if not isinstance(use_raw, Mapping):
+        use_rawd = use_raw
+        use_raw = defaultdict(lambda: use_rawd)
+    if not isinstance(layer, Mapping):
+        layerd = layer
+        layer = defaultdict(lambda: layerd)
+    if not isinstance(gene_symbols, Mapping):
+        gene_symbolsd = gene_symbols
+        gene_symbols = defaultdict(lambda: gene_symbolsd)
+
     if color is None:
         ad = AnnData(obs=obs, obsm=adata.obsm, obsp=adata.obsp)
         return sc.pl.embedding(ad, basis=basis_mod, **kwargs)
@@ -170,9 +179,12 @@ def embedding(
     keys = color
 
     varidx = {}
-    for modname, mod in data.mod.items():
-        var = mod.var if not use_raw else mod.raw.var
-        varidx[modname] = var.index if gene_symbols is None else pd.Index(var[gene_symbols])
+    for m, mod in data.mod.items():
+        if layer[m] is not None and use_raw[m]:
+            raise ValueError("use_raw cannot be True when a layer is specified.")
+
+        var = mod.var if not use_raw[m] else mod.raw.var
+        varidx[m] = var.index if gene_symbols[m] is None else pd.Index(var[gene_symbols[m]])
 
     # Fetch respective features
     if not all(key in obs for key in keys):
@@ -198,7 +210,11 @@ def embedding(
                 mod_keys = [mod_key_modifier[k] for i, k in enumerate(keys) if keys_in_mod[m][i]]
                 obs = obs.join(
                     sc.get.obs_df(
-                        mod, keys=mod_keys, layer=layer, use_raw=use_raw, gene_symbols=gene_symbols
+                        mod,
+                        keys=mod_keys,
+                        layer=layer[m],
+                        use_raw=use_raw[m],
+                        gene_symbols=gene_symbols[m],
                     ),
                     how="left",
                 )

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -121,6 +121,9 @@ def embedding(
     if isinstance(data, AnnData):
         return sc.pl.embedding(data, basis=basis, color=color, use_raw=use_raw, layer=layer, **kwargs)
 
+    if use_raw and layer is not None:
+        raise ValueError("use_raw cannot be True when a layer is specified.")
+
     # `data` is MuData
     if basis not in data.obsm and "X_" + basis in data.obsm:
         basis = "X_" + basis
@@ -200,10 +203,8 @@ def embedding(
 
                 if use_raw is None or use_raw:
                     if data.mod[m].raw is not None:
-                        keysidx = data.mod[m].raw.var.index.get_indexer_for(mod_keys)
-                        fmod_adata = AnnData(
-                            X=data.mod[m].raw.X[:, keysidx], var=pd.DataFrame(index=mod_keys), obs=data.mod[m].obs
-                        )
+                        subset = data.mod[m].raw[:, mod_keys]
+                        fmod_adata = AnnData(X=subset.X, var=subset.var, obs=data.mod[m].obs)
                     else:
                         if use_raw:
                             warnings.warn(f"Attibute .raw is None for the modality {m}, using .X instead", stacklevel=2)

--- a/src/muon/pl.py
+++ b/src/muon/pl.py
@@ -94,6 +94,7 @@ def embedding(
     color: str | Sequence[str] | None = None,
     use_raw: bool | None = None,
     layer: str | Mapping[str, str | None] | None = None,
+    gene_symbols: str | None = None,
     **kwargs,
 ) -> Axes | list[Axes] | None:
     """Scatter plot for .obs.
@@ -116,10 +117,11 @@ def embedding(
             in order to use a different layer for each modality.
             No layer is used by default. If a valid `layer` is provided, this takes precedence
             over `use_raw=True`.
+        gene_symbols: Column of `.var` to search for `color` in.
         **kwargs: Additional keyword arguments passed to :func:`scanpy.pl.embedding`.
     """
     if isinstance(data, AnnData):
-        return sc.pl.embedding(data, basis=basis, color=color, use_raw=use_raw, layer=layer, **kwargs)
+        return sc.pl.embedding(data, basis=basis, color=color, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, **kwargs)
 
     if use_raw and layer is not None:
         raise ValueError("use_raw cannot be True when a layer is specified.")
@@ -167,73 +169,39 @@ def embedding(
         raise TypeError("Expected color to be a string or an iterable.")
     keys = color
 
+    varidx = {}
+    for modname, mod in data.mod.items():
+        var = mod.var if not use_raw else mod.raw.var
+        varidx[modname] = var.index if gene_symbols is None else pd.Index(var[gene_symbols])
+
     # Fetch respective features
     if not all(key in obs for key in keys):
         # {'rna': [True, False], 'prot': [False, True]}
-        keys_in_mod = {m: [key in data.mod[m].var_names for key in keys] for m in data.mod}
-
-        # .raw slots might have exclusive var_names
-        if use_raw is None or use_raw:
-            for i, k in enumerate(keys):
-                for m in data.mod:
-                    if not keys_in_mod[m][i] and data.mod[m].raw is not None:
-                        keys_in_mod[m][i] = k in data.mod[m].raw.var_names
+        keys_in_mod = {m: [key in varidx[m] for key in keys] for m in data.mod}
 
         # e.g. color="rna:CD8A" - especially relevant for mdata.axis == -1
         mod_key_modifier: dict[str, str] = {}
         for i, k in enumerate(keys):
             mod_key_modifier[k] = k
-            for m in data.mod:
+            for m, mod in data.mod.items():
                 if not keys_in_mod[m][i]:
                     k_clean = k
                     if k.startswith(f"{m}:"):
                         k_clean = k.split(":", 1)[1]
 
-                    keys_in_mod[m][i] = k_clean in data.mod[m].var_names
+                    keys_in_mod[m][i] = k_clean in varidx[m]
                     if keys_in_mod[m][i]:
                         mod_key_modifier[k] = k_clean
-                    if use_raw is None or use_raw:
-                        if not keys_in_mod[m][i] and data.mod[m].raw is not None:
-                            keys_in_mod[m][i] = k_clean in data.mod[m].raw.var_names
 
-        for m in data.mod:
+        for m, mod in data.mod.items():
             if np.sum(keys_in_mod[m]) > 0:
-                mod_keys = np.array(keys)[keys_in_mod[m]]
-                mod_keys = np.array([mod_key_modifier[k] for k in mod_keys])
-
-                if use_raw is None or use_raw:
-                    if data.mod[m].raw is not None:
-                        subset = data.mod[m].raw[:, mod_keys]
-                        fmod_adata = AnnData(X=subset.X, var=subset.var, obs=data.mod[m].obs)
-                    else:
-                        if use_raw:
-                            warnings.warn(f"Attibute .raw is None for the modality {m}, using .X instead", stacklevel=2)
-                        fmod_adata = data.mod[m][:, mod_keys]
-                else:
-                    fmod_adata = data.mod[m][:, mod_keys]
-
-                if layer is not None:
-                    if isinstance(layer, Mapping):
-                        m_layer = layer.get(m, None)
-                        if m_layer is not None:
-                            xlayer = data.mod[m][:, mod_keys].layers[m_layer]
-                            fmod_adata.X = xlayer.toarray() if isinstance(layer, spmatrix | sparray) else xlayer
-                            if use_raw:
-                                warnings.warn(f"Layer='{layer}' superseded use_raw={use_raw}", stacklevel=2)
-                    elif layer in data.mod[m].layers:
-                        xlayer = data.mod[m][:, mod_keys].layers[layer]
-                        fmod_adata.X = xlayer.toarray() if isinstance(xlayer, spmatrix | sparray) else xlayer
-                        if use_raw:
-                            warnings.warn(f"Layer='{layer}' superseded use_raw={use_raw}", stacklevel=2)
-                    else:
-                        warnings.warn(
-                            f"Layer {layer} is not present for the modality {m}, using count matrix instead",
-                            stacklevel=2,
-                        )
-                x: np.ndarray | spmatrix | sparray = fmod_adata.X
-                if isinstance(x, spmatrix | sparray):
-                    x = x.toarray()
-                obs = obs.join(pd.DataFrame(x, columns=mod_keys, index=fmod_adata.obs_names), how="left")
+                mod_keys = [mod_key_modifier[k] for i, k in enumerate(keys) if keys_in_mod[m][i]]
+                obs = obs.join(
+                    sc.get.obs_df(
+                        mod, keys=mod_keys, layer=layer, use_raw=use_raw, gene_symbols=gene_symbols
+                    ),
+                    how="left",
+                )
 
         color = [mod_key_modifier[k] for k in keys]
 

--- a/src/muon/utils.py
+++ b/src/muon/utils.py
@@ -36,9 +36,8 @@ def _get_values(
         use_raw: Use `.raw` attribute of the modality where a feature (from `color`) is derived from.
             If a mapping is given, it must have one entry for each modality.
         layer: Name of the layer in the modality where a feature (from `color`) is derived from.
-            No layer is used by default. If a valid `layer` is provided, this takes precedence
-            over `use_raw=True`. If a mapping is given, it must have one entry for each modality.
-        gene_symbols: Column of `.var` to search for `color` in. If a mapping is given, it must have
+            No layer is used by default. If a mapping is given, it must have one entry for each modality.
+        gene_symbols: Column of `.var` to search for `key` in. If a mapping is given, it must have
             one entry for each modality.
         obsmap: Provide a vector of the desired size were 0 are missing values and non-zero values
             correspond to the 1-based index of the value.
@@ -52,7 +51,9 @@ def _get_values(
         if m is not None:
             # Avoid numpy conversion of uint indices to float
             m = m.astype(int)
-            return pd.Series([vec[i - 1] if i != 0 else np.nan for i in m]).values
+            values = pd.Series(dtype=pd.core.dtypes.cast.convert_dtypes(vec), index=pd.RangeIndex(len(m)))
+            values.iloc[m[m > 0] - 1] = vec
+            return values.array
         return vec
 
     # Handle multiple keys
@@ -79,7 +80,8 @@ def _get_values(
         and (
             gene_symbols is None
             and key not in data.var_names
-            or gene_symbols is not None
+            or isinstance(gene_symbols, str)
+            and gene_symbols in data.var.columns
             and key not in data.var[gene_symbols]
         )
         and key not in data.obsm
@@ -118,6 +120,14 @@ def _get_values(
         if key_mod and mod_key:
             if not data.obs_names.equals(data.mod[key_mod].obs_names) and obsmap is None:
                 obsmap = data.obsmap[key_mod]
+            if isinstance(gene_symbols, Mapping):
+                gene_symbols = gene_symbols[key_mod]
+            elif gene_symbols is not None and gene_symbols.startswith(f"{key_mod}:"):
+                gene_symbols = gene_symbols[len(key_mod) + 1 :]
+            if isinstance(layer, Mapping):
+                layer = layer[key_mod]
+            elif layer is not None and layer.startswith(f"{key_mod}:"):
+                layer = layer[len(key_mod) + 1]
             return _get_values(
                 data.mod[key_mod], key=mod_key, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, obsmap=obsmap
             )
@@ -156,18 +166,7 @@ def _get_values(
         if use_raw and layer is not None:
             raise ValueError("use_raw cannot be True when a layer is specified.")
 
-        if use_raw:
-            keysidx = (
-                data.raw.var.index.get_indexer_for([key])
-                if gene_symbols is None
-                else np.nonzero(data.raw.var[gene_symbols] == key)[0]
-            )
-            if len(keysidx) == 0 or keysidx == -1:
-                raise ValueError(f"Key {key} could not be found.")
-            values = data.raw.X[:, keysidx[0]]
-            if len(keysidx) > 1:
-                warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
-        elif layer is not None:
+        if layer is not None:
             keysidx = (
                 data.var.index.get_indexer_for([key])
                 if gene_symbols is None
@@ -176,6 +175,17 @@ def _get_values(
             if len(keysidx) == 0 or keysidx == -1:
                 raise ValueError(f"Key {key} could not be found.")
             values = data.layers[layer][:, keysidx[0]]  # type: ignore[index]
+            if len(keysidx) > 1:
+                warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
+        elif use_raw:
+            keysidx = (
+                data.raw.var.index.get_indexer_for([key])
+                if gene_symbols is None
+                else np.nonzero(data.raw.var[gene_symbols] == key)[0]
+            )
+            if len(keysidx) == 0 or keysidx == -1:
+                raise ValueError(f"Key {key} could not be found.")
+            values = data.raw.X[:, keysidx[0]]
             if len(keysidx) > 1:
                 warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
         else:

--- a/src/muon/utils.py
+++ b/src/muon/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping
 
 import numpy as np
 import pandas as pd
@@ -12,9 +12,10 @@ from scipy.sparse import sparray, spmatrix
 
 def _get_values(
     data: AnnData | MuData,
-    key: str | Sequence[str] | None = None,
-    use_raw: bool | None = None,
-    layer: str | None = None,
+    key: str | Iterable[str] | None = None,
+    use_raw: bool | Mapping[str, bool] = False,
+    layer: str | Mapping[str, str | None] | None = None,
+    gene_symbols: str | Mapping[str, str | None] | None = None,
     obsmap: np.ndarray | None = None,
 ) -> Iterable | None:
     """A helper function to get values for variables or annotations of observations (.obs columns).
@@ -30,13 +31,15 @@ def _get_values(
     available in .obs so that scanpy.pl interface can be reused.
 
     Args:
-        data: MuData or AnnData object
-        key: String to search for
+        data: MuData or AnnData object.
+        key: String to search for.
         use_raw: Use `.raw` attribute of the modality where a feature (from `color`) is derived from.
-            If `None`, defaults to `True` if `.raw` is present and a valid `layer` is not provided.
+            If a mapping is given, it must have one entry for each modality.
         layer: Name of the layer in the modality where a feature (from `color`) is derived from.
             No layer is used by default. If a valid `layer` is provided, this takes precedence
-            over `use_raw=True`.
+            over `use_raw=True`. If a mapping is given, it must have one entry for each modality.
+        gene_symbols: Column of `.var` to search for `color` in. If a mapping is given, it must have
+            one entry for each modality.
         obsmap: Provide a vector of the desired size were 0 are missing values and non-zero values
             correspond to the 1-based index of the value.
             This is used internally for when AnnData as a modality has less observations
@@ -54,7 +57,9 @@ def _get_values(
 
     # Handle multiple keys
     if isinstance(key, Iterable) and not isinstance(key, str):
-        all_values = [_get_values(data, k, use_raw=use_raw, layer=layer, obsmap=obsmap) for k in key]
+        all_values = [
+            _get_values(data, k, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, obsmap=obsmap) for k in key
+        ]
         df = pd.DataFrame(all_values).T
         df.columns = [k for k in key if k is not None]
         return df
@@ -69,7 +74,16 @@ def _get_values(
 
     # Handle composite keys, e.g. rna:n_counts
     key_mod, mod_key = None, None
-    if isinstance(data, MuData) and key not in data.var_names and key not in data.obsm:
+    if (
+        isinstance(data, MuData)
+        and (
+            gene_symbols is None
+            and key not in data.var_names
+            or gene_symbols is not None
+            and key not in data.var[gene_symbols]
+        )
+        and key not in data.obsm
+    ):
         if ":" in key:
             maybe_mod, maybe_key = key.split(":", 1)
             if maybe_mod in data.mod:
@@ -104,31 +118,19 @@ def _get_values(
         if key_mod and mod_key:
             if not data.obs_names.equals(data.mod[key_mod].obs_names) and obsmap is None:
                 obsmap = data.obsmap[key_mod]
-            return _get_values(data.mod[key_mod], key=mod_key, use_raw=use_raw, layer=layer, obsmap=obsmap)
+            return _get_values(
+                data.mod[key_mod], key=mod_key, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, obsmap=obsmap
+            )
 
         # {'rna': True, 'prot': False}
-        key_in_mod = {m: key in data.mod[m].var_names for m in data.mod}
+        key_in_mod = {}
+        for m, mod in data.mod.items():
+            if layer is not None and use_raw:
+                raise ValueError("use_raw cannot be True when a layer is specified.")
 
-        # Check if the valid layer is requested
-        if layer is not None:
-            if sum(key_in_mod.values()) == 1:
-                use_mod = [m for m, v in key_in_mod.items() if v][0]
-                valid_layer = layer in data.mod[use_mod].layers
-                if not valid_layer:
-                    warnings.warn(
-                        f"Layer {layer} is not present when searching for the key {key}, using count matrix instead",
-                        stacklevel=2,
-                    )
-                    layer = None
-
-        # .raw slots might have exclusive var_names
-        if (use_raw is None or use_raw) and layer is None:
-            for m in data.mod:
-                if not key_in_mod[m] and data.mod[m].raw is not None:
-                    key_in_mod[m] = key in data.mod[m].raw.var_names
-                    if key_in_mod[m] and data.mod[m].raw is None and layer is None:
-                        warnings.warn(f"Attibute .raw is None for the modality {m}, using .X instead", stacklevel=2)
-                        use_raw = False
+            var = mod.var if not use_raw else mod.raw.var
+            varidx = var.index if gene_symbols is None else var[gene_symbols]
+            key_in_mod[m] = key in varidx
 
         if sum(key_in_mod.values()) == 0:
             pass  # not in var names
@@ -140,39 +142,49 @@ def _get_values(
             use_mod = [m for m, v in key_in_mod.items() if v][0]
             if not data.obs_names.equals(data.mod[use_mod].obs_names) and obsmap is None:
                 obsmap = data.obsmap[use_mod]
-            return _get_values(data.mod[use_mod], key=key, use_raw=use_raw, layer=layer, obsmap=obsmap)
+            if isinstance(use_raw, Mapping):
+                use_raw = use_raw[use_mod]
+            if isinstance(layer, Mapping):
+                layer = layer[use_mod]
+            if isinstance(gene_symbols, Mapping):
+                gene_symbols = gene_symbols[use_mod]
+            return _get_values(
+                data.mod[use_mod], key=key, use_raw=use_raw, layer=layer, gene_symbols=gene_symbols, obsmap=obsmap
+            )
 
     elif isinstance(data, AnnData):
-        if (use_raw is None or use_raw) and data.raw is not None and layer is None:
-            keysidx = data.raw.var.index.get_indexer_for([key])
-            if keysidx == -1:
+        if use_raw and layer is not None:
+            raise ValueError("use_raw cannot be True when a layer is specified.")
+
+        if use_raw:
+            keysidx = (
+                data.raw.var.index.get_indexer_for([key])
+                if gene_symbols is None
+                else np.nonzero(data.raw.var[gene_symbols] == key)[0]
+            )
+            if len(keysidx) == 0 or keysidx == -1:
                 raise ValueError(f"Key {key} could not be found.")
             values = data.raw.X[:, keysidx[0]]
             if len(keysidx) > 1:
                 warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
-
-        elif layer is not None and layer in data.layers:
-            if layer in data.layers:
-                keysidx = data.var.index.get_indexer_for([key])
-                if keysidx == -1:
-                    raise ValueError(f"Key {key} could not be found.")
-                layer_matrix: np.ndarray | sparray | spmatrix = data.layers[layer]
-                values = layer_matrix[:, keysidx[0]]
-                if use_raw:
-                    warnings.warn(f"Layer='{layer}' superseded use_raw={use_raw}", stacklevel=2)
-                if len(keysidx) > 1:
-                    warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
-
+        elif layer is not None:
+            keysidx = (
+                data.var.index.get_indexer_for([key])
+                if gene_symbols is None
+                else np.nonzero(data.var[gene_symbols] == key)[0]
+            )
+            if len(keysidx) == 0 or keysidx == -1:
+                raise ValueError(f"Key {key} could not be found.")
+            values = data.layers[layer][:, keysidx[0]]  # type: ignore[index]
+            if len(keysidx) > 1:
+                warnings.warn(f"Key {key} is not unique in the index, using the first value...", stacklevel=2)
         else:
-            if (use_raw is None or use_raw) and data.raw is None:
-                warnings.warn(f"Attibute .raw is None when searching for the key {key}, using .X instead", stacklevel=2)
-            if layer is not None and layer not in data.layers:
-                warnings.warn(
-                    f"Layer {layer} is not present when searching for the key {key}, using count matrix instead",
-                    stacklevel=2,
-                )
-            keysidx = data.var.index.get_indexer_for([key])
-            if keysidx == -1:
+            keysidx = (
+                data.var.index.get_indexer_for([key])
+                if gene_symbols is None
+                else np.nonzero(data.var[gene_symbols] == key)[0]
+            )
+            if len(keysidx) == 0 or keysidx == -1:
                 raise ValueError(f"Key {key} could not be found.")
             x = data.X
             if x is None:


### PR DESCRIPTION
This PR attempts to make `.pl.scatter` and `pl.embedding` more predictable while simplifying our code and fixing some bugs.
- `use_raw` can no longer be `None`, it is either `True` or `False`. This is consistent with the scanpy API, leads to more predictable output, and allows us to considerably simplify our code.
- a new argument `gene_symbols` is supported, with the same functionality as in scanpy.
- the arguments `layer`, `use_raw`, and `gene_symbols` can be specified individually for each modality by passing dictionaries.