### PR TITLE
fix: handle random_state=0 correctly in leiden clustering

### DIFF
--- a/muon/_core/tools.py
+++ b/muon/_core/tools.py
@@ -1002,7 +1002,7 @@ def _cluster(
         partition_type = alg.RBConfigurationVertexPartition
 
     optimiser = alg.Optimiser()
-    if random_state:
+    if random_state is not None:
         optimiser.set_rng_seed(random_state)
 
     # The same as leiden.find_partition_multiplex() (louvain.find_partition_multiplex())

--- a/tests/test_leiden_random_state.py
+++ b/tests/test_leiden_random_state.py
@@ -1,0 +1,51 @@
+"""Test that random_state=0 correctly sets the RNG seed in leiden/louvain clustering."""
+
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import scanpy as sc
+from anndata import AnnData
+from mudata import MuData
+
+import muon as mu
+
+
+def _make_mudata():
+    """Create a minimal MuData with precomputed neighbors."""
+    np.random.seed(42)
+    a = AnnData(np.random.rand(50, 10).astype(np.float32))
+    b = AnnData(np.random.rand(50, 10).astype(np.float32))
+    sc.pp.neighbors(a)
+    sc.pp.neighbors(b)
+    return MuData({"a": a, "b": b})
+
+
+def test_leiden_random_state_zero_sets_seed():
+    """Regression test for https://github.com/scverse/muon/issues/154.
+
+    random_state=0 must call optimiser.set_rng_seed(0), not skip it.
+    """
+    mdata = _make_mudata()
+
+    with patch("leidenalg.Optimiser") as MockOptimiser:
+        mock_opt = MagicMock()
+        mock_opt.optimise_partition_multiplex.return_value = 0.0
+        MockOptimiser.return_value = mock_opt
+
+        mu.tl.leiden(mdata, random_state=0)
+
+        mock_opt.set_rng_seed.assert_called_once_with(0)
+
+
+def test_leiden_random_state_none_skips_seed():
+    """When random_state is None, set_rng_seed should not be called."""
+    mdata = _make_mudata()
+
+    with patch("leidenalg.Optimiser") as MockOptimiser:
+        mock_opt = MagicMock()
+        mock_opt.optimise_partition_multiplex.return_value = 0.0
+        MockOptimiser.return_value = mock_opt
+
+        mu.tl.leiden(mdata, random_state=None)
+
+        mock_opt.set_rng_seed.assert_not_called()

--- a/tests/test_leiden_random_state.py
+++ b/tests/test_leiden_random_state.py
@@ -1,6 +1,8 @@
 """Test that random_state=0 correctly sets the RNG seed in leiden/louvain clustering."""
 
-from unittest.mock import patch, MagicMock
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
 
 import numpy as np
 import scanpy as sc
@@ -20,32 +22,74 @@ def _make_mudata():
     return MuData({"a": a, "b": b})
 
 
+def _make_mock_leidenalg():
+    """Create a mock leidenalg module with the interfaces the code needs."""
+    mock_module = ModuleType("leidenalg")
+
+    mock_optimiser_instance = MagicMock()
+    mock_optimiser_instance.optimise_partition_multiplex.return_value = 0.0
+
+    mock_partition = MagicMock()
+    mock_partition.membership = [0] * 50
+
+    mock_optimiser_cls = MagicMock(return_value=mock_optimiser_instance)
+    mock_partition_cls = MagicMock(return_value=mock_partition)
+
+    mock_module.Optimiser = mock_optimiser_cls
+    mock_module.RBConfigurationVertexPartition = mock_partition_cls
+
+    # Also mock the VertexPartition submodule so module-level imports work.
+    vp = ModuleType("leidenalg.VertexPartition")
+    vp.MutableVertexPartition = MagicMock()
+    mock_module.VertexPartition = vp
+
+    return mock_module, mock_optimiser_instance
+
+
 def test_leiden_random_state_zero_sets_seed():
     """Regression test for https://github.com/scverse/muon/issues/154.
 
     random_state=0 must call optimiser.set_rng_seed(0), not skip it.
     """
     mdata = _make_mudata()
+    mock_module, mock_opt = _make_mock_leidenalg()
 
-    with patch("leidenalg.Optimiser") as MockOptimiser:
-        mock_opt = MagicMock()
-        mock_opt.optimise_partition_multiplex.return_value = 0.0
-        MockOptimiser.return_value = mock_opt
-
+    saved = sys.modules.get("leidenalg")
+    saved_vp = sys.modules.get("leidenalg.VertexPartition")
+    try:
+        sys.modules["leidenalg"] = mock_module
+        sys.modules["leidenalg.VertexPartition"] = mock_module.VertexPartition
         mu.tl.leiden(mdata, random_state=0)
-
         mock_opt.set_rng_seed.assert_called_once_with(0)
+    finally:
+        if saved is None:
+            sys.modules.pop("leidenalg", None)
+        else:
+            sys.modules["leidenalg"] = saved
+        if saved_vp is None:
+            sys.modules.pop("leidenalg.VertexPartition", None)
+        else:
+            sys.modules["leidenalg.VertexPartition"] = saved_vp
 
 
 def test_leiden_random_state_none_skips_seed():
     """When random_state is None, set_rng_seed should not be called."""
     mdata = _make_mudata()
+    mock_module, mock_opt = _make_mock_leidenalg()
 
-    with patch("leidenalg.Optimiser") as MockOptimiser:
-        mock_opt = MagicMock()
-        mock_opt.optimise_partition_multiplex.return_value = 0.0
-        MockOptimiser.return_value = mock_opt
-
+    saved = sys.modules.get("leidenalg")
+    saved_vp = sys.modules.get("leidenalg.VertexPartition")
+    try:
+        sys.modules["leidenalg"] = mock_module
+        sys.modules["leidenalg.VertexPartition"] = mock_module.VertexPartition
         mu.tl.leiden(mdata, random_state=None)
-
         mock_opt.set_rng_seed.assert_not_called()
+    finally:
+        if saved is None:
+            sys.modules.pop("leidenalg", None)
+        else:
+            sys.modules["leidenalg"] = saved
+        if saved_vp is None:
+            sys.modules.pop("leidenalg.VertexPartition", None)
+        else:
+            sys.modules["leidenalg.VertexPartition"] = saved_vp


### PR DESCRIPTION
## Summary

- Fix falsy check on `random_state` in `_cluster()` that caused `random_state=0` to skip setting the RNG seed
- Changed `if random_state:` to `if random_state is not None:` so that `0` (the default) correctly calls `optimiser.set_rng_seed(0)`
- Added regression tests verifying seed is set for `random_state=0` and skipped for `random_state=None`

## Root cause

In `muon/_core/tools.py` line 1005, the condition `if random_state:` evaluates to `False` when `random_state=0` because `0` is falsy in Python. This meant the default value (`random_state=0`) and any explicit `random_state=0` call never set the RNG seed, producing non-deterministic clustering results.

Closes #154

## Test plan

- [ ] `test_leiden_random_state_zero_sets_seed` — verifies `set_rng_seed(0)` is called when `random_state=0`
- [ ] `test_leiden_random_state_none_skips_seed` — verifies `set_rng_seed` is not called when `random_state=None`