### PR TITLE
Fix prot.pp.clr for old-style sparse matrices

### DIFF
--- a/muon/_prot/preproc.py
+++ b/muon/_prot/preproc.py
@@ -227,7 +227,7 @@ def dsb(
 def clr(
     adata: AnnData,
     inplace: bool = True,
-    axis: int = 0,
+    axis: Literal[0, 1] = 0,
     flavor: Literal["seurat", "stoeckius", "standard"] = "seurat",
 ) -> AnnData | None:
     """
@@ -274,7 +274,14 @@ def clr(
                 )
                 x = x.tocsr()
 
-            x.data /= np.repeat(np.exp(np.log1p(x).mean(axis=axis).toarray()), x.getnnz(axis=axis))
+            logmean = np.log1p(x).mean(axis=axis)
+            if isinstance(x, csc_matrix | csr_matrix):
+                logmean = logmean.A
+                nnz = x.getnnz(axis=axis)
+            else:
+                nnz = np.diff(x.indptr)  # https://github.com/scipy/scipy/issues/19405
+
+            x.data /= np.repeat(np.exp(logmean), nnz)
             np.log1p(x.data, out=x.data)
         else:
             np.log1p(x / np.exp(np.log1p(x).mean(axis=axis, keepdims=True)), out=x)


### PR DESCRIPTION
### Problem

`muon.prot.pp.clr` crashes on the seurat flavor when `adata.X` is an old-style SciPy sparse matrix (`csc_matrix` / `csr_matrix`):

```python
mu.prot.pp.clr(adata, axis=1)
# AttributeError: 'matrix' object has no attribute 'toarray'
```

For an `spmatrix`, `np.log1p(x).mean(axis=axis)` returns a `numpy.matrix`, which has no `.toarray()` method, so the existing line fails. This affects common datasets whose ADT `.X` is still an `spmatrix` (e.g. `papalexi_2021`).

### Fix

Compute the per-feature log-mean once and coerce it to a plain array depending on the container type:

- old-style `csc_matrix` / `csr_matrix`: use `.A` and `x.getnnz(axis=axis)`
- sparse arrays: use `np.diff(x.indptr)` to avoid the `getnnz` behavior change (scipy/scipy#19405)

The `axis` type hint is also tightened to `Literal[0, 1]`.

### Verification

Installed this branch and ran the pertpy `perturbation_efficacy` tutorial (which calls `mu.prot.pp.clr(mdata["adt"], axis=1)` on `papalexi_2021`) end-to-end: all 32 code cells execute with no errors. CLR output on both `axis=0` and `axis=1` is finite, non-negative, and preserves sparsity as expected for the seurat flavor.