### PR TITLE
Avoid FutureWarning from deprecated scanpy.__version__

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,11 @@ Release notes
 
    *
 
+v0.1.10
+-------
+
+* Avoid a ``FutureWarning`` on import by querying the scanpy version via :func:`importlib.metadata.version` instead of the deprecated ``scanpy.__version__``.
+
 v0.1.9
 ------
 

--- a/muon/_core/preproc.py
+++ b/muon/_core/preproc.py
@@ -19,7 +19,6 @@ from scipy.special import softmax
 from sklearn.utils import check_random_state
 
 from anndata import AnnData
-import scanpy
 from scanpy import logging
 from scanpy.tools._utils import _choose_representation
 from pynndescent.distances import euclidean
@@ -27,9 +26,11 @@ from pynndescent.sparse import sparse_euclidean, sparse_jaccard
 from umap.umap_ import nearest_neighbors
 from numba import njit, prange
 
+from importlib.metadata import version
+
 from packaging.version import Version
 
-if Version(scanpy.__version__) < Version("1.10"):
+if Version(version("scanpy")) < Version("1.10"):
     from scanpy.neighbors import _compute_connectivities_umap as __compute_connectivities_umap
 
     _compute_connectivities_umap = lambda *args, **kwargs: __compute_connectivities_umap(


### PR DESCRIPTION
## Description

Importing muon emits a `FutureWarning` on recent scanpy versions:

```
muon/_core/preproc.py:31: FutureWarning: `__version__` is deprecated, use `importlib.metadata.version('scanpy')` instead
  if Version(scanpy.__version__) < Version("1.10"):
```

The version guard now queries the installed scanpy version via `importlib.metadata.version("scanpy")` instead of the deprecated `scanpy.__version__`, matching scanpy's own recommendation. The bare `import scanpy` is dropped since every remaining reference uses `from scanpy import ...`.

Verified that `import muon` no longer raises a `FutureWarning` (with `warnings.simplefilter("error", FutureWarning)`) against scanpy 1.12.1, and the `< 1.10` branch selection is unchanged.

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)