### PR TITLE
Fix leiden/louvain ignoring random_state=0

### DIFF
--- a/muon/_core/tools.py
+++ b/muon/_core/tools.py
@@ -1002,7 +1002,7 @@ def _cluster(
         partition_type = alg.RBConfigurationVertexPartition
 
     optimiser = alg.Optimiser()
-    if random_state:
+    if random_state is not None:
         optimiser.set_rng_seed(random_state)
 
     # The same as leiden.find_partition_multiplex() (louvain.find_partition_multiplex())

--- a/tests/test_muon_tools.py
+++ b/tests/test_muon_tools.py
@@ -152,6 +152,7 @@ class TestMOFA2D:
 def test_leiden_random_state_zero_seeds_rng():
     # Regression test for https://github.com/scverse/muon/issues/154
     # `random_state=0` is falsy, so it used to be skipped and the RNG left unseeded.
+    pytest.importorskip("leidenalg")
     rng = np.random.default_rng(0)
     ad1 = AnnData(rng.random((50, 20)))
     ad2 = AnnData(rng.random((50, 20)))

--- a/tests/test_muon_tools.py
+++ b/tests/test_muon_tools.py
@@ -1,9 +1,11 @@
 import pytest
 import unittest
+from unittest import mock
 
 import numpy as np
 from scipy import sparse
 import pandas as pd
+import scanpy as sc
 from anndata import AnnData
 import muon as mu
 from muon import MuData
@@ -145,6 +147,22 @@ class TestMOFA2D:
         for sample, value in (("sample9_groupA", -1.719391), ("sample17_groupB", 2.057848)):
             si = np.where(mdata.obs.index == sample)[0]
             assert mdata.obsm["X_mofa"][si, 0].item() == pytest.approx(value)
+
+
+def test_leiden_random_state_zero_seeds_rng():
+    # Regression test for https://github.com/scverse/muon/issues/154
+    # `random_state=0` is falsy, so it used to be skipped and the RNG left unseeded.
+    rng = np.random.default_rng(0)
+    ad1 = AnnData(rng.random((50, 20)))
+    ad2 = AnnData(rng.random((50, 20)))
+    sc.pp.neighbors(ad1, random_state=0)
+    sc.pp.neighbors(ad2, random_state=0)
+    mdata = MuData({"m1": ad1, "m2": ad2})
+
+    with mock.patch("leidenalg.Optimiser") as optimiser_cls:
+        optimiser = optimiser_cls.return_value
+        mu.tl.leiden(mdata, random_state=0, key_added="leiden")
+        optimiser.set_rng_seed.assert_called_once_with(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #154

Changes proposed in this pull request:
- Fix `mu.tl.leiden` / `mu.tl.louvain` ignoring `random_state=0`, which left the optimiser's RNG unseeded and made the default seed non-reproducible.
- Add a regression test asserting `Optimiser.set_rng_seed(0)` is called when `random_state=0`.

## Test log

```
$ .venv/bin/python -m pytest tests/test_muon_tools.py::test_leiden_random_state_zero_seeds_rng -q
1 passed in 8.59s
```
