### PR TITLE
Raise ValueError instead of assert for invalid mod_weights/resolution

### DIFF
--- a/muon/_core/plot.py
+++ b/muon/_core/plot.py
@@ -222,7 +222,7 @@ def embedding(
                     if data.mod[m].raw is not None:
                         keysidx = data.mod[m].raw.var.index.get_indexer_for(mod_keys)
                         fmod_adata = AnnData(
-                            X=data.mod[m].raw.X[:, keysidx],
+                            X=data.mod[m].raw.X[:, keysidx].copy(),
                             var=pd.DataFrame(index=mod_keys),
                             obs=data.mod[m].obs,
                         )
@@ -231,9 +231,9 @@ def embedding(
                             warnings.warn(
                                 f"Attibute .raw is None for the modality {m}, using .X instead"
                             )
-                        fmod_adata = data.mod[m][:, mod_keys]
+                        fmod_adata = data.mod[m][:, mod_keys].copy()
                 else:
-                    fmod_adata = data.mod[m][:, mod_keys]
+                    fmod_adata = data.mod[m][:, mod_keys].copy()
 
                 if layer is not None:
                     if isinstance(layer, Dict):

--- a/muon/_core/tools.py
+++ b/muon/_core/tools.py
@@ -1002,7 +1002,7 @@ def _cluster(
         partition_type = alg.RBConfigurationVertexPartition
 
     optimiser = alg.Optimiser()
-    if random_state:
+    if random_state is not None:
         optimiser.set_rng_seed(random_state)
 
     # The same as leiden.find_partition_multiplex() (louvain.find_partition_multiplex())

--- a/muon/_core/tools.py
+++ b/muon/_core/tools.py
@@ -989,9 +989,10 @@ def _cluster(
         if isinstance(mod_weights, Mapping):
             layer_weights = [mod_weights.get(mod, 1) for mod in mdata.mod]
         elif isinstance(mod_weights, Sequence) and not isinstance(mod_weights, str):
-            assert len(mod_weights) == len(
-                mdata.mod
-            ), f"Length of layers_weights ({len(mod_weights)}) does not match the number of modalities ({len(mdata.mod)})"
+            if len(mod_weights) != len(mdata.mod):
+                raise ValueError(
+                    f"Length of layers_weights ({len(mod_weights)}) does not match the number of modalities ({len(mdata.mod)})"
+                )
             layer_weights = mod_weights
         else:
             layer_weights = [mod_weights for _ in mdata.mod]
@@ -1015,9 +1016,10 @@ def _cluster(
                 for mod in mdata.mod
             ]
         elif isinstance(resolution, Sequence) and not isinstance(resolution, str):
-            assert len(resolution) == len(
-                mdata.mod
-            ), f"Length of resolution ({len(resolution)}) does not match the number of modalities ({len(mdata.mod)})"
+            if len(resolution) != len(mdata.mod):
+                raise ValueError(
+                    f"Length of resolution ({len(resolution)}) does not match the number of modalities ({len(mdata.mod)})"
+                )
             parts = [
                 partition_type(gs[mod], resolution_parameter=resolution[i], **partition_kwargs)
                 for i, mod in enumerate(mdata.mod)

--- a/tests/test_muon_plot.py
+++ b/tests/test_muon_plot.py
@@ -1,8 +1,11 @@
+import warnings
+
 import pytest
 
 import numpy as np
 from scipy import sparse
 import pandas as pd
+import anndata
 from anndata import AnnData
 import muon as mu
 from muon import MuData
@@ -29,3 +32,23 @@ class TestScatter:
         np.random.seed(42)
         mdata.obs["condition"] = np.random.choice(["a", "b"], mdata.n_obs)
         mu.pl.scatter(mdata, x="mod1:0", y="mod2:0", color="condition")
+
+
+def test_embedding_layer_does_not_mutate():
+    # Regression test for https://github.com/scverse/muon/issues/183
+    rng = np.random.default_rng(0)
+    n_obs, n_var = 20, 5
+    X = rng.random((n_obs, n_var))
+    ad = AnnData(X=X.copy())
+    ad.var_names = [f"g{i}" for i in range(n_var)]
+    ad.layers["counts"] = X.copy() * 10
+    ad.obsm["X_umap"] = rng.random((n_obs, 2))
+    mdata = MuData({"mod": ad})
+
+    X_before = mdata["mod"].X.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", anndata.ImplicitModificationWarning)
+        mu.pl.embedding(mdata, basis="mod:umap", color="g0", layer="counts", show=False)
+
+    assert np.array_equal(X_before, mdata["mod"].X)

--- a/tests/test_muon_tools.py
+++ b/tests/test_muon_tools.py
@@ -166,5 +166,19 @@ def test_leiden_random_state_zero_seeds_rng():
         optimiser.set_rng_seed.assert_called_once_with(0)
 
 
+def test_leiden_mod_weights_length_raises():
+    # Regression test for https://github.com/scverse/muon/issues/220
+    pytest.importorskip("leidenalg")
+    rng = np.random.default_rng(0)
+    ad1 = AnnData(rng.random((30, 10)))
+    ad2 = AnnData(rng.random((30, 10)))
+    sc.pp.neighbors(ad1, random_state=0)
+    sc.pp.neighbors(ad2, random_state=0)
+    mdata = MuData({"m1": ad1, "m2": ad2})
+
+    with pytest.raises(ValueError, match="Length of layers_weights"):
+        mu.tl.leiden(mdata, mod_weights=[1, 2, 3], random_state=0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_muon_tools.py
+++ b/tests/test_muon_tools.py
@@ -152,6 +152,7 @@ class TestMOFA2D:
 def test_leiden_random_state_zero_seeds_rng():
     # Regression test for https://github.com/scverse/muon/issues/154
     # `random_state=0` is falsy, so it used to be skipped and the RNG left unseeded.
+    pytest.importorskip("leidenalg")
     rng = np.random.default_rng(0)
     ad1 = AnnData(rng.random((50, 20)))
     ad2 = AnnData(rng.random((50, 20)))

--- a/tests/test_muon_tools.py
+++ b/tests/test_muon_tools.py
@@ -1,9 +1,11 @@
 import pytest
 import unittest
+from unittest import mock
 
 import numpy as np
 from scipy import sparse
 import pandas as pd
+import scanpy as sc
 from anndata import AnnData
 import muon as mu
 from muon import MuData
@@ -145,6 +147,22 @@ class TestMOFA2D:
         for sample, value in (("sample9_groupA", -1.719391), ("sample17_groupB", 2.057848)):
             si = np.where(mdata.obs.index == sample)[0]
             assert mdata.obsm["X_mofa"][si, 0].item() == pytest.approx(value)
+
+
+def test_leiden_random_state_zero_seeds_rng():
+    # Regression test for https://github.com/scverse/muon/issues/154
+    # `random_state=0` is falsy, so it used to be skipped and the RNG left unseeded.
+    rng = np.random.default_rng(0)
+    ad1 = AnnData(rng.random((50, 20)))
+    ad2 = AnnData(rng.random((50, 20)))
+    sc.pp.neighbors(ad1, random_state=0)
+    sc.pp.neighbors(ad2, random_state=0)
+    mdata = MuData({"m1": ad1, "m2": ad2})
+
+    with mock.patch("leidenalg.Optimiser") as optimiser_cls:
+        optimiser = optimiser_cls.return_value
+        mu.tl.leiden(mdata, random_state=0, key_added="leiden")
+        optimiser.set_rng_seed.assert_called_once_with(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #220

Changes proposed in this pull request:
- Replace `assert` with explicit `raise ValueError` for the `mod_weights` and `resolution` length checks in `mu.tl.leiden`/`mu.tl.louvain` (stripped under `python -O`).
- Add a regression test.